### PR TITLE
Added a HEAD request route handler and integration testa

### DIFF
--- a/addon/route-handlers/shorthands/head.js
+++ b/addon/route-handlers/shorthands/head.js
@@ -1,0 +1,75 @@
+import assert from 'ember-cli-mirage/assert';
+import BaseShorthandRouteHandler from './base';
+import { Response } from 'ember-cli-mirage';
+import { singularize, camelize } from 'ember-cli-mirage/utils/inflector';
+
+export default class HeadShorthandRouteHandler extends BaseShorthandRouteHandler {
+
+  /*
+    Retrieve a model/collection from the db.
+
+    Examples:
+      this.head('/contacts', 'contact');
+      this.head('/contacts/:id', 'contact');
+  */
+  handleStringShorthand(request, modelClass) {
+    let modelName = this.shorthand;
+    let camelizedModelName = camelize(modelName);
+
+    assert(
+      modelClass,
+      `The route handler for ${request.url} is trying to access the ${camelizedModelName} model, but that model doesn't exist. Create it using 'ember g mirage-model ${modelName}'.`
+    );
+
+    let id = this._getIdForRequest(request);
+    if (id) {
+      let model = modelClass.find(id);
+      if (!model) {
+        return new Response(404);
+      } else {
+        return new Response(204);
+      }
+    } else if (this.options.coalesce && request.queryParams && request.queryParams.ids) {
+      let model = modelClass.find(request.queryParams.ids);
+
+      if (!model) {
+        return new Response(404);
+      } else {
+        return new Response(204);
+      }
+    } else {
+      return new Response(204);
+    }
+  }
+
+  /*
+    Retrieve an array of collections from the db.
+
+    Ex: this.head('/home', ['contacts', 'pictures']);
+  */
+  handleArrayShorthand(request, modelClasses) {
+    let keys = this.shorthand;
+    let id = this._getIdForRequest(request);
+
+    /*
+    If the first key is singular and we have an id param in
+    the request, we're dealing with the version of the shorthand
+    that has a parent model and several has-many relationships.
+    We throw an error, because the serializer is the appropriate
+    place for this now.
+    */
+    assert(
+      !id || singularize(keys[0]) !== keys[0],
+      `It looks like you're using the "Single record with
+      related records" version of the array shorthand, in addition to opting
+      in to the model layer. This shorthand was made when there was no
+      serializer layer. Now that you're using models, please ensure your
+      relationships are defined, and create a serializer for the parent
+      model, adding the relationships there.`
+    );
+
+    return new Response(204);
+  }
+
+}
+

--- a/tests/integration/route-handlers/head-shorthand-test.js
+++ b/tests/integration/route-handlers/head-shorthand-test.js
@@ -1,0 +1,137 @@
+import { module, test } from 'qunit';
+import {
+  Model,
+  hasMany,
+  belongsTo,
+  JSONAPISerializer,
+  Response
+} from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+import HeadShorthandRouteHandler from 'ember-cli-mirage/route-handlers/shorthands/head';
+
+module('Integration | Route Handlers | HEAD shorthand', {
+  beforeEach() {
+    this.server = new Server({
+      environment: 'development',
+      models: {
+        author: Model,
+        photo: Model
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+
+    this.authors = [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' },
+      { id: 3, name: 'Epona' }
+    ];
+    this.photos = [
+      { id: 1, title: 'Amazing', location: 'Hyrule' },
+      { id: 2, title: 'Photo', location: 'Goron City' }
+    ];
+    this.server.db.loadData({
+      authors: this.authors,
+      photos: this.photos
+    });
+
+    this.schema = this.server.schema;
+    this.serializer = new JSONAPISerializer();
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('undefined shorthand with an ID that is not in the DB will return a 404 Response', function(assert) {
+  let request = { url: '/authors', params: { id: 101 } };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 404);
+});
+
+test('undefined shorthand with an ID that is in the DB will return a 204 Response', function(assert) {
+  let request = { url: '/authors', params: { id: 1 } };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('undefined shorthand with coalesce true will return a 204 response if one of the IDs are found', function(assert) {
+  let request = { url: '/authors?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+  let options = { coalesce: true };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors', options);
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('undefined shorthand string (no id) shorthand returns a 204 (regardless of the length of the collection)', function(assert) {
+  let request = { url: '/authors' };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('string shorthand with an ID that is not in the DB will return a 404 Response', function(assert) {
+  let request = { url: '/authors', params: { id: 101 } };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, 'author');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 404);
+});
+
+test('string shorthand with an ID that is in the DB will return a 204 Response', function(assert) {
+  let request = { url: '/authors', params: { id: 1 } };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, 'author');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('string shorthand with coalesce true will return a 204 response if one of the IDs are found', function(assert) {
+  let request = { url: '/authors?ids[]=1&ids[]=3', queryParams: { ids: [1, 3] } };
+  let options = { coalesce: true };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, 'author', '/people', options);
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('string shorthand string (no id) shorthand returns a 204 (regardless of the length of the collection)', function(assert) {
+  let request = { url: '/authors' };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, 'author');
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});
+
+test('array shorthand will return a 204 response', function(assert) {
+  let url = '/home';
+  let request = { url };
+  let handler = new HeadShorthandRouteHandler(this.schema, this.serializer, ['authors', 'photos'], url);
+
+  let response = handler.handle(request);
+
+  assert.ok(response instanceof Response);
+  assert.equal(response.code, 204);
+});


### PR DESCRIPTION
- returns a 204 Response if a single model is found
- returns a 404 Response if a single model was expected and not found
- returns a 204 Response if a collection was found